### PR TITLE
add simple check to ensure ./syft is present before proceeding in the make_sboms.sh script

### DIFF
--- a/scripts/make_sboms.sh
+++ b/scripts/make_sboms.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ ! -x './syft' ]; then
+    echo "Command ./syft must exist and be executable"
+    exit 1
+fi
+
 # construct full set of input images
 IMAGES=`cat input_images/* | sort | uniq`
 
@@ -27,3 +32,4 @@ do
     echo
 done
 date > ./results/last_updated
+exit 0


### PR DESCRIPTION

Signed-off-by: Daniel Nurmi <nurmi@anchore.com>